### PR TITLE
updates to work with ollama v0.1.29

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+VERSION

--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 #FROM docker.io/nvidia/cuda:12.2.2-runtime-ubi9
-FROM docker.io/nvidia/cuda:12.2.2-devel-ubi9
+FROM docker.io/nvidia/cuda:12.3.2-devel-ubi9
 
 LABEL maintainer=william.caban@gmail.com \
       io.k8s.display-name="Ollama AI" \

--- a/Containerfile.build
+++ b/Containerfile.build
@@ -1,11 +1,18 @@
-FROM docker.io/nvidia/cuda:12.2.2-devel-ubi9
+FROM docker.io/nvidia/cuda:12.3.2-devel-ubi9
 
 ARG VERSION
+ARG GOLANG_VERSION=1.22.1
+ARG CMAKE_VERSION=3.22.1
 
 RUN dnf -y update \
-    && dnf install -y --nodocs pciutils cmake golang git \
-    && dnf clean all && rm -rf /var/cache/* \
-    && git clone --depth 1 --branch $VERSION https://github.com/jmorganca/ollama.git
+    && dnf install -y --nodocs pciutils git
+
+# The cmake and golang dependencies require special logic
+COPY ./scripts/rh_linux_deps.sh /
+RUN CMAKE_VERSION=${CMAKE_VERSION} GOLANG_VERSION=${GOLANG_VERSION} sh /rh_linux_deps.sh
+
+RUN dnf clean all && rm -rf /var/cache/* \
+    && git clone --depth 1 --branch $VERSION https://github.com/ollama/ollama.git
 
 #USER root
 WORKDIR /ollama
@@ -14,7 +21,7 @@ RUN go generate ./... \
     && go build . \
     && ls -l /ollama
 
-FROM docker.io/nvidia/cuda:12.2.2-runtime-ubi9
+FROM docker.io/nvidia/cuda:12.3.2-runtime-ubi9
 
 RUN dnf -y update \
     && dnf install -y --nodocs pciutils \

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ applications. It also supports a wide range of programming languages and framewo
 
 ## Accessing OLLAMA API
 
-- The available models will be accesible over the `ollama` [API](https://github.com/jmorganca/ollama/blob/main/docs/api.md) which defaults to http://localhost:11434
+- The available models will be accesible over the `ollama` [API](https://github.com/ollama/ollama/blob/main/docs/api.md) which defaults to http://localhost:11434
     - For deployments to OpenShift using the manifests in this repo get the URL for your application by executing `oc get route ollama-route -n ollama`
 
 ```bash

--- a/build.sh
+++ b/build.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 
-OLLAMA_VERSION=$(curl -s "https://api.github.com/repos/jmorganca/ollama/releases/latest" | jq -r .name)
+OLLAMA_VERSION=$(curl -s "https://api.github.com/repos/ollama/ollama/releases/latest" | jq -r .name)
 
 echo ${OLLAMA_VERSION} > VERSION
 
 podman build --no-cache --build-arg=VERSION=${OLLAMA_VERSION} -t quay.io/wcaban/ollama:latest -f Containerfile.build
 podman tag quay.io/wcaban/ollama:latest quay.io/wcaban/ollama:${OLLAMA_VERSION}
 
+# Moved to upload.sh
 #podman push quay.io/wcaban/ollama:latest
 #podman push quay.io/wcaban/ollama:${OLLAMA_VERSION}

--- a/scripts/rh_linux_deps.sh
+++ b/scripts/rh_linux_deps.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# Script for common Dockerfile dependency installation in redhat linux based images
+
+set -ex
+MACHINE=$(uname -m)
+
+if [ -n "${CMAKE_VERSION}" ]; then
+    curl -s -L https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz | tar -zx -C /usr --strip-components 1
+fi
+
+if [ -n "${GOLANG_VERSION}" ]; then
+    if [ "${MACHINE}" = "x86_64" ]; then
+        GO_ARCH="amd64"
+#    elif [ "${MACHINE}" = "aarch64" ]; then
+#        GO_ARCH="aarch64"
+    else
+        GO_ARCH="arm64"
+    fi
+    mkdir -p /usr/local
+    curl -s -L https://dl.google.com/go/go${GOLANG_VERSION}.linux-${GO_ARCH}.tar.gz | tar xz -C /usr/local
+    ln -s /usr/local/go/bin/go /usr/local/bin/go
+    ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+fi


### PR DESCRIPTION
Ollama v1.29 requires: GOLANG_VERSION=1.22.1 and CMAKE_VERSION=3.22.1
I also thought it would be best to pull code from /ollama/ollama instead of /jmorganca/ollama and get the latest versions of the nvidia/cuda images.
Give it a try to see if it works for you!